### PR TITLE
fix: protect against duplicates with nonzero assets in withdrawTo arg…

### DIFF
--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {Id} from "../../lib/metamorpho/src/interfaces/IMetaMorpho.sol";
+import {Id, MarketParams} from "../../lib/metamorpho/src/interfaces/IMetaMorpho.sol";
+import {Withdrawal} from "../interfaces/IPublicAllocator.sol";
 
 /// @title ErrorsLib
 /// @author Morpho Labs
@@ -37,4 +38,7 @@ library ErrorsLib {
 
     /// @notice Thrown when the value is already set.
     error AlreadySet();
+
+    /// @notice Thrown when there are duplicates with nonzero assets in `withdrawTo` arguments.
+    error InconsistentWithdrawTo(Withdrawal[] withdrawals, MarketParams depositMarketParams);
 }


### PR DESCRIPTION
**Summary**
Protects against duplicates in the reallocation-by-flow approach. 

It works like this:
1. Accumulate the sum of expected withdraw amounts as `totalWithdrawn`.
2. Set `depositAllocation.assets` to `type(uint).max` value, then call `vault.reallocate`.
3. Check that the balance of the deposit market increased by `totalWithdrawn`.

It reverts on:
- Duplicates in `withdrawals` with two nonzero `amount`
- Duplicate in `withdrawals` with one nonzero `amount` first, then one zero `amount`
  - Spurious revert but does not matter.
- The deposit market is present in `withdrawals` with a nonzero `assets`.

**Alterative approach**

1. Set `depositAllocation.assets = totalSupplyAssets + totalWithdrawn`.

```diff
--- a/src/PublicAllocator.sol
+++ b/src/PublicAllocator.sol
@@ -99,16 +99,17 @@ contract PublicAllocator is IPublicAllocatorStaticTyping {
         uint totalSupplyAssetsBefore = MORPHO.totalSupplyAssets(depositMarketId);
 
         allocations[withdrawals.length].marketParams = depositMarketParams;
-        allocations[withdrawals.length].assets = type(uint).max;
+        uint depositAssets = totalSupplyAssetsBefore + totalWithdrawn;
+        if (depositAssets == type(uint).max) revert("NoUintMaxDeposit()");
+        allocations[withdrawals.length].assets = depositAssets;
 
         VAULT.reallocate(allocations);
 
         Market memory depositMarket = MORPHO.market(depositMarketId);
 
-        // Protect against duplicates with nonzero amounts in withdrawals
-        if (depositMarket.totalSupplyAssets - totalSupplyAssetsBefore != totalWithdrawn) {
-            revert ErrorsLib.InconsistentWithdrawTo(withdrawals,depositMarketParams);
-        }

```

It will revert in the same cases. 

**Why not the alternative approach**
- You need a special case when `totalSupplyAssets + totalWithdrawn = type(uint).max` since MetaMorpho takes that as a special case. Otherwise you lose the duplicate protection.
- The error raised is a `transferFrom` error (insufficient balance) which is less clear than in this PR which has a clear error.