### PR TITLE
hardcode evm version to paris

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 libs = ["lib"]
 via_ir = true
 optimizer_runs = 999999
+evm_version = "paris"
 
 [profile.default.rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"


### PR DESCRIPTION
Default evm version of foundry is paris (for the moment), let's hardcode it in case it changes.