### PR TITLE
chore: remove bytecode hash from compilation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,8 +5,8 @@ libs = ["lib"]
 via_ir = true
 optimizer = true
 optimizer_runs = 999999
-evm_version = "paris"
 bytecode_hash = "none"
+evm_version = "paris"
 
 [profile.default.rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 via_ir = true
 optimizer_runs = 999999
 evm_version = "paris"
+bytecode_hash = "none"
 
 [profile.default.rpc_endpoints]
 mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 via_ir = true
+optimizer = true
 optimizer_runs = 999999
 evm_version = "paris"
 bytecode_hash = "none"


### PR DESCRIPTION
[This](https://github.com/foundry-rs/foundry/pull/9657) foundry change is breaking, so we need to explicitly turn on the optimizer